### PR TITLE
Update vertical.css to resolve breaking of wrapping functionality.

### DIFF
--- a/css/vertical.css
+++ b/css/vertical.css
@@ -25,3 +25,15 @@
 #board.vertical-trello-mixed .list {
     max-height: 50%;
 }
+
+/*
+* Fixes for Trello update; They added a list-wrapper component that broke the extension.
+*/
+.list-wrapper {
+    overflow-x: hidden;
+	overflow-y: auto !important;
+    margin: 0 0 10px 10px;
+    width: 260px;
+    height:300px;
+    float:left;
+}


### PR DESCRIPTION
I tested this by injecting the inline CSS into the Trello page to get wrapping working once again but not with the extension as a whole. Not quite sure on regression with toggling it on and off but it should be sufficient.